### PR TITLE
Use pkg-config instead of freetype-config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For the `textlabel` tool, the following development packages are required (liste
 
 * libfreetype6-dev
 * libfontconfig1-dev
+* pkgconf
 
 `make` builds the main interface binary, the textlabel tool and line2bitmap.
 

--- a/makefile
+++ b/makefile
@@ -2,8 +2,8 @@
 export PREFIX ?= /usr
 
 CFLAGS ?= -Wall -g
-textlabel: CFLAGS += $(shell freetype-config --cflags)
-textlabel: LDLIBS += $(shell freetype-config --libs) -lfontconfig
+textlabel: CFLAGS += $(shell pkg-config --cflags freetype2)
+textlabel: LDLIBS += $(shell pkg-config --libs freetype2) -lfontconfig
 
 all: pt1230 textlabel line2bitmap
 


### PR DESCRIPTION
Since freetype2 2.9.1 the freetype-config tool is deprecated. The recommended alternative is pkg-config.
(see also: README for version 2.9.1 https://sourceforge.net/projects/freetype/files/freetype2/2.9.1/ )

fixes #9